### PR TITLE
Forward original client IP to auth request

### DIFF
--- a/src/authorize.js
+++ b/src/authorize.js
@@ -26,7 +26,7 @@ function isBlurred({ region, size }) {
   return false;
 }
 
-async function authorize(params, referer, cookie) {
+async function authorize(params, referer, cookie, clientIp) {
   if (params.filename == "info.json") return true;
   if (isBlurred(params)) return true;
 
@@ -36,15 +36,16 @@ async function authorize(params, referer, cookie) {
 
   const id = params.id.split("/").slice(-1)[0];
 
-  return await getImageAuthorization(id, cookie);
+  return await getImageAuthorization(id, cookie, clientIp);
 }
 
-async function getImageAuthorization(id, cookieHeader) {
+async function getImageAuthorization(id, cookieHeader, clientIp) {
   const opts = {
     headers: {
       cookie: cookieHeader,
     },
   };
+  if (clientIp) opts.headers["x-client-ip"] = clientIp;
 
   const response = await fetch(
     `$${dcApiEndpoint}/file-sets/$${id}/authorization`,

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ async function viewerRequestIiif(request) {
   const params = parsePath(path);
   const referer = getEventHeader(request, "referer");
   const cookie = getEventHeader(request, "cookie");
-  const authed = await authorize(params, referer, cookie);
+  const authed = await authorize(params, referer, cookie, request.clientIp);
   console.log("Authorized:", authed);
 
   // Return a 403 response if not authorized to view the requested item


### PR DESCRIPTION
This is the IIIF side of the same auth flow enhancement described by nulib/dc-api-v2#80.

This code has already been deployed to staging.